### PR TITLE
Remove packet.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ A curated list of Minio community projects inspired by [awesome-go](https://gith
 * [Ha-Minio](https://github.com/bryanl/ha-minio) - Configures Minio, as a S3 compatible cloud storage server for DigitalOcean in a highly available fashion.
 * [Onlinetech](http://www.onlinetech.com) - Secure, compliant enterprise cloud.
 * [OVH](https://www.ovh.com/us/) - Build your own infrastructure with OVH public cloud..
-* [Packet](https://www.packet.net) - Packet is a baremetal cloud provider.
 * [Plumbery](http://plumbery.readthedocs.io/en/latest/tutorial.minio.html) -  Plumbery is an open source project that was initiated by Dimension Data to accelerate digital transformation. It recommends using Minio as a standalone object storage.
 * [s3-tus-store](https://github.com/blockai/s3-tus-store) - Minio is the supported storage backend for [https://tus.io/](https://tus.io/). Tus is an open protocol for resumable file uploads.
 * [ScaleWay](https://www.scaleway.com) - Scalable and affordable cloud and bare-metal servers (European DC).


### PR DESCRIPTION
No longer offering services under this brand/site.

> Packet was acquired by Equinix in March. To help make our vision for global, interconnected bare metal a reality, we've rebranded Packet as Equinix Metal™